### PR TITLE
point to couchbase fork of go-couchbase

### DIFF
--- a/n1ql.go
+++ b/n1ql.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/couchbaselabs/go-couchbase"
+	"github.com/couchbase/go-couchbase"
 )
 
 // Common error codes


### PR DESCRIPTION
This makes it easier to use in a Sync Gateway experiment I'm working on.
